### PR TITLE
Update easylist_cookie_specific_hide.txt

### DIFF
--- a/easylist_cookie/easylist_cookie_specific_hide.txt
+++ b/easylist_cookie/easylist_cookie_specific_hide.txt
@@ -2431,7 +2431,7 @@ cancerfonden.se,pen-broker.ru##div[class^="CookieDisclaimer"]
 !! .overLay
 abundantgracetabernacle.org.uk,destemma.org,pacificandgold.co.uk##.overLay
 !! .CookieConsent
-bakkenbaeck.com,bluemail.me,buildclub.com,business-standard.com,cmodx.com,e-ville.com,fiorentinabaseball.it,forbesafrica.com,fotmob.com,geeksforgeeks.org,haveibeentrained.com,likewisetv.com,nebula.tv,nordlayer.com,nordlocker.com,ocbase.com,officedepot.hu,opyn.co,pango.education,pichau.com.br,rcskinclinic.com,reflexer.finance,salvagemarket.co.uk,sankei.com,senda.pl,shuttle.rs,soldfy.se,sprintmedical.in,streamerbans.com,tayama.pl,u.sb,ubank.co.za,upgrade.chat,wheels.ca,zakzak.co.jp##.CookieConsent
+bakkenbaeck.com,bluemail.me,buildclub.com,business-standard.com,cmodx.com,e-ville.com,fiorentinabaseball.it,forbesafrica.com,fotmob.com,geeksforgeeks.org,haveibeentrained.com,likewisetv.com,nebula.tv,nordlayer.com,nordlocker.com,ocbase.com,officedepot.hu,opyn.co,pango.education,pichau.com.br,puhekupla.com,rcskinclinic.com,reflexer.finance,salvagemarket.co.uk,sankei.com,senda.pl,senpa.io,shuttle.rs,soldfy.se,sprintmedical.in,streamerbans.com,tayama.pl,u.sb,ubank.co.za,upgrade.chat,wheels.ca,zakzak.co.jp##.CookieConsent
 !! .m-smartbar-container
 hilti.com,hilti.dk,hilti.ru##.m-smartbar-container
 !! #policy-ribbon


### PR DESCRIPTION
Hide cookie notices on `puhekupla.com` and `senpa.io`.
![Screenshot from 2023-06-29 20-27-24](https://github.com/Sonic5435325/easylist/assets/89158249/5613ea8f-85e5-4e8f-8fd3-5126cea8bd7e)
![Screenshot from 2023-06-29 20-28-58](https://github.com/Sonic5435325/easylist/assets/89158249/1db81db6-dc24-4036-a5dc-8fa0dc2b67c9)
